### PR TITLE
fix: increase entity limit to 5mb

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { ValidationPipe } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import expressBasicAuth from 'express-basic-auth';
 import cookieParser from 'cookie-parser';
+import { json } from 'express';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -18,6 +19,7 @@ async function bootstrap() {
       },
     }),
   );
+  app.use(json({ limit: '5mb' }));
   app.use(cookieParser());
 
   app.useGlobalPipes(


### PR DESCRIPTION
요청 body entity 크기를 5mb로 명시(증가)하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the application to support larger JSON payloads (up to 5MB) for incoming requests. 

- **Bug Fixes**
	- Improved the handling of JSON requests, ensuring better performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->