### PR TITLE
chore: increate request body entity limit to 10mb

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import { ValidationPipe } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import expressBasicAuth from 'express-basic-auth';
 import cookieParser from 'cookie-parser';
-import { json } from 'express';
+import { json, urlencoded } from 'express';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -19,7 +19,9 @@ async function bootstrap() {
       },
     }),
   );
-  app.use(json({ limit: '5mb' }));
+  app.use(json({ limit: '10mb' }));
+  app.use(urlencoded({ limit: '10mb', extended: true }));
+
   app.use(cookieParser());
 
   app.useGlobalPipes(


### PR DESCRIPTION
요청 body entity limit을 10mb로 재설정함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced middleware configuration to support larger request bodies for both JSON and URL-encoded data, increasing limits to 10MB.

- **Bug Fixes**
	- Improved handling of larger payloads, reducing potential errors when submitting extensive data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->