### PR TITLE
feat: add building module and apply to post module

### DIFF
--- a/prisma/migrations/20241208162457_add_building_and_location_detail/migration.sql
+++ b/prisma/migrations/20241208162457_add_building_and_location_detail/migration.sql
@@ -1,0 +1,21 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `location` on the `post` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "post" DROP COLUMN "location";
+
+-- CreateTable
+CREATE TABLE "building" (
+    "id" SERIAL NOT NULL,
+    "name" VARCHAR(255) NOT NULL,
+    "enName" VARCHAR(255) NOT NULL,
+    "gps" VARCHAR(255) NOT NULL,
+    "code" VARCHAR(50) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "building_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/migrations/20241208170035_add_buildingname_unique_property/migration.sql
+++ b/prisma/migrations/20241208170035_add_buildingname_unique_property/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[name]` on the table `building` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "building_name_key" ON "building"("name");

--- a/prisma/migrations/20241208173953_connect_post_building/migration.sql
+++ b/prisma/migrations/20241208173953_connect_post_building/migration.sql
@@ -1,0 +1,21 @@
+/*
+  Warnings:
+
+  - You are about to alter the column `name` on the `building` table. The data in that column could be lost. The data in that column will be cast from `VarChar(255)` to `VarChar(20)`.
+  - You are about to alter the column `enName` on the `building` table. The data in that column could be lost. The data in that column will be cast from `VarChar(255)` to `VarChar(20)`.
+  - You are about to alter the column `gps` on the `building` table. The data in that column could be lost. The data in that column will be cast from `VarChar(255)` to `VarChar(30)`.
+  - You are about to alter the column `code` on the `building` table. The data in that column could be lost. The data in that column will be cast from `VarChar(50)` to `VarChar(4)`.
+
+*/
+-- AlterTable
+ALTER TABLE "building" ALTER COLUMN "name" SET DATA TYPE VARCHAR(20),
+ALTER COLUMN "enName" SET DATA TYPE VARCHAR(20),
+ALTER COLUMN "gps" SET DATA TYPE VARCHAR(30),
+ALTER COLUMN "code" SET DATA TYPE VARCHAR(4);
+
+-- AlterTable
+ALTER TABLE "post" ADD COLUMN     "buildingId" INTEGER NOT NULL DEFAULT 2,
+ADD COLUMN     "locationDetail" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "post" ADD CONSTRAINT "post_buildingId_fkey" FOREIGN KEY ("buildingId") REFERENCES "building"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -48,23 +48,41 @@ enum PostType {
 }
 
 model Post {
-  id          Int          @id @default(autoincrement())
+  id          Int      @id @default(autoincrement())
   type        PostType
-  title       String       @db.VarChar(255)
-  description String       @db.Text
+  title       String   @db.VarChar(255)
+  description String   @db.Text
   images      String[]
-  location    String
-  category    ItemCategory @default(ETC)
-  status      PostStatus
-  createdAt   DateTime     @default(now())
-  updatedAt   DateTime     @updatedAt
-  deletedAt   DateTime?
+
+  category  ItemCategory @default(ETC)
+  status    PostStatus
+  createdAt DateTime     @default(now())
+  updatedAt DateTime     @updatedAt
+  deletedAt DateTime?
 
   authorId String    @db.Uuid
   author   User      @relation(fields: [authorId], references: [uuid])
   Comment  Comment[]
 
+  // buildingId     Int      @default(1)
+  // Building       Building @relation(fields: [buildingId], references: [id])
+  // locationDetail String? // 세부 위치
+
   @@map("post")
+}
+
+model Building {
+  id     Int    @id @default(autoincrement())
+  name   String @db.VarChar(255)
+  enName String @db.VarChar(255)
+  gps    String @db.VarChar(255)
+  code   String @db.VarChar(50) // 건물 번호 e.g. E11
+  // posts  Post[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("building")
 }
 
 enum CommentType {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -73,7 +73,7 @@ model Post {
 
 model Building {
   id     Int    @id @default(autoincrement())
-  name   String @db.VarChar(255)
+  name   String @unique() @db.VarChar(255)
   enName String @db.VarChar(255)
   gps    String @db.VarChar(255)
   code   String @db.VarChar(50) // 건물 번호 e.g. E11

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -62,22 +62,22 @@ model Post {
 
   authorId String    @db.Uuid
   author   User      @relation(fields: [authorId], references: [uuid])
-  Comment  Comment[]
+  comment  Comment[]
 
-  // buildingId     Int      @default(1)
-  // Building       Building @relation(fields: [buildingId], references: [id])
-  // locationDetail String? // 세부 위치
+  buildingId     Int      @default(2)
+  building       Building @relation(fields: [buildingId], references: [id])
+  locationDetail String? // 세부 위치
 
   @@map("post")
 }
 
 model Building {
   id     Int    @id @default(autoincrement())
-  name   String @unique() @db.VarChar(255)
-  enName String @db.VarChar(255)
-  gps    String @db.VarChar(255)
-  code   String @db.VarChar(50) // 건물 번호 e.g. E11
-  // posts  Post[]
+  name   String @unique() @db.VarChar(20)
+  enName String @db.VarChar(20)
+  gps    String @db.VarChar(30)
+  code   String @db.VarChar(4) // 건물 번호 e.g. E11
+  posts  Post[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,7 @@ import { UserModule } from './user/user.module';
 import { PostModule } from './post/post.module';
 import { ImageModule } from './image/image.module';
 import { CommentModule } from './comment/comment.module';
+import { BuildingModule } from './building/building.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { CommentModule } from './comment/comment.module';
     PostModule,
     ImageModule,
     CommentModule,
+    BuildingModule,
   ],
   controllers: [AppController],
   providers: [],

--- a/src/building/building.controller.ts
+++ b/src/building/building.controller.ts
@@ -1,0 +1,90 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+} from '@nestjs/common';
+import {
+  ApiInternalServerErrorResponse,
+  ApiNoContentResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+import { BuildingService } from './building.service';
+import { CreateBuildingDto } from './dto/req/createBuilding.dto';
+import { BuildingResponseDto } from './dto/res/buildingRes.dto';
+import { UpdateBuildingDto } from './dto/req/updateBuilding.dto';
+
+@ApiTags('Building')
+@Controller('building')
+export class BuildingController {
+  constructor(private buildingService: BuildingService) {}
+
+  @ApiOperation({
+    summary: 'create building',
+    description: 'register building information',
+  })
+  @ApiOkResponse({
+    type: BuildingResponseDto,
+    description: 'Return Created Building',
+  })
+  @ApiInternalServerErrorResponse({
+    description: 'Internal Server Error',
+  })
+  @Post()
+  async createBuilding(
+    @Body() createBuildingDto: CreateBuildingDto,
+  ): Promise<BuildingResponseDto> {
+    return this.buildingService.createBuilding(createBuildingDto);
+  }
+
+  @ApiOperation({
+    summary: 'get all buildings',
+    description: 'get all buildings information',
+  })
+  @ApiOkResponse({
+    type: [BuildingResponseDto],
+    description: 'Return All Buildings',
+  })
+  @ApiInternalServerErrorResponse({
+    description: 'Internal Server Error',
+  })
+  @Get()
+  async getAllBuildings(): Promise<BuildingResponseDto[]> {
+    return this.buildingService.getAllBuildings();
+  }
+
+  @ApiOperation({
+    summary: 'update building',
+    description: 'update building',
+  })
+  @ApiOkResponse({
+    type: BuildingResponseDto,
+    description: 'Return updated building',
+  })
+  @Patch(':id')
+  async updateBuilding(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() updateBuildingDto: UpdateBuildingDto,
+  ): Promise<BuildingResponseDto> {
+    return this.buildingService.updateBuilding(id, updateBuildingDto);
+  }
+
+  @ApiOperation({
+    summary: 'delete building',
+    description: 'delete building',
+  })
+  @ApiNoContentResponse({ description: 'No content returned' })
+  @ApiInternalServerErrorResponse({
+    description: 'Internal Server Error',
+  })
+  @Delete(':id')
+  async deletePost(@Param('id', ParseIntPipe) id: number): Promise<void> {
+    return this.buildingService.deleteBuilding(id);
+  }
+}

--- a/src/building/building.controller.ts
+++ b/src/building/building.controller.ts
@@ -84,7 +84,7 @@ export class BuildingController {
     description: 'Internal Server Error',
   })
   @Delete(':id')
-  async deletePost(@Param('id', ParseIntPipe) id: number): Promise<void> {
+  async deleteBuilding(@Param('id', ParseIntPipe) id: number): Promise<void> {
     return this.buildingService.deleteBuilding(id);
   }
 }

--- a/src/building/building.module.ts
+++ b/src/building/building.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { BuildingController } from './building.controller';
+import { PrismaModule } from 'src/prisma/prisma.module';
+import { BuildingService } from './building.service';
+import { BuildingRepository } from './building.repository';
+
+@Module({
+  imports: [PrismaModule],
+  providers: [BuildingService, BuildingRepository],
+  controllers: [BuildingController],
+})
+export class BuildingModule {}

--- a/src/building/building.module.ts
+++ b/src/building/building.module.ts
@@ -8,5 +8,6 @@ import { BuildingRepository } from './building.repository';
   imports: [PrismaModule],
   providers: [BuildingService, BuildingRepository],
   controllers: [BuildingController],
+  exports: [BuildingService],
 })
 export class BuildingModule {}

--- a/src/building/building.repository.ts
+++ b/src/building/building.repository.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { CreateBuildingDto } from './dto/req/createBuilding.dto';
+import { UpdateBuildingDto } from './dto/req/updateBuilding.dto';
+import { BuildingResponseDto } from './dto/res/buildingRes.dto';
+
+@Injectable()
+export class BuildingRepository {
+  constructor(private prismaService: PrismaService) {}
+
+  async createBuilding(
+    createBuildingDto: CreateBuildingDto,
+  ): Promise<BuildingResponseDto> {
+    return this.prismaService.building.create({
+      data: {
+        ...createBuildingDto,
+      },
+    });
+  }
+
+  async getAllBuildings(): Promise<BuildingResponseDto[]> {
+    return this.prismaService.building.findMany({
+      where: {},
+    });
+  }
+
+  async getBuildingByName(name: string): Promise<BuildingResponseDto> {
+    return this.prismaService.building.findUnique({
+      where: { name },
+    });
+  }
+
+  async getBuildingById(id: number): Promise<BuildingResponseDto> {
+    return this.prismaService.building.findUnique({
+      where: { id },
+    });
+  }
+
+  async updateBuilding(
+    id: number,
+    updateBuildingDto: UpdateBuildingDto,
+  ): Promise<BuildingResponseDto> {
+    const updatedBuilding = await this.prismaService.building.update({
+      where: { id },
+      data: updateBuildingDto,
+    });
+
+    return updatedBuilding;
+  }
+
+  async deleteBuilding(id: number): Promise<void> {
+    await this.prismaService.building.delete({
+      where: { id },
+    });
+  }
+}

--- a/src/building/building.service.ts
+++ b/src/building/building.service.ts
@@ -1,0 +1,53 @@
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { CreateBuildingDto } from './dto/req/createBuilding.dto';
+import { BuildingRepository } from './building.repository';
+import { UpdateBuildingDto } from './dto/req/updateBuilding.dto';
+import { BuildingResponseDto } from './dto/res/buildingRes.dto';
+
+@Injectable()
+export class BuildingService {
+  constructor(private buildingRepository: BuildingRepository) {}
+
+  async createBuilding(
+    createBuildingDto: CreateBuildingDto,
+  ): Promise<BuildingResponseDto> {
+    const building = await this.buildingRepository.getBuildingByName(
+      createBuildingDto.name,
+    );
+
+    if (building) {
+      throw new ConflictException('Building name already exists.');
+    }
+
+    return this.buildingRepository.createBuilding(createBuildingDto);
+  }
+
+  async getAllBuildings(): Promise<BuildingResponseDto[]> {
+    return this.buildingRepository.getAllBuildings();
+  }
+
+  async updateBuilding(
+    id: number,
+    updateBuildingDto: UpdateBuildingDto,
+  ): Promise<BuildingResponseDto> {
+    const building = await this.buildingRepository.getBuildingById(id);
+    if (!building) {
+      throw new NotFoundException('Building not found.');
+    }
+
+    return this.buildingRepository.updateBuilding(id, updateBuildingDto);
+  }
+
+  async deleteBuilding(id: number): Promise<void> {
+    const building = await this.buildingRepository.getBuildingById(id);
+    if (!building) {
+      throw new NotFoundException('Building not found.');
+    }
+
+    return this.buildingRepository.deleteBuilding(id);
+  }
+}

--- a/src/building/building.service.ts
+++ b/src/building/building.service.ts
@@ -50,4 +50,8 @@ export class BuildingService {
 
     return this.buildingRepository.deleteBuilding(id);
   }
+
+  async getBuildingById(id: number): Promise<BuildingResponseDto> {
+    return this.buildingRepository.getBuildingById(id);
+  }
 }

--- a/src/building/dto/req/createBuilding.dto.ts
+++ b/src/building/dto/req/createBuilding.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsNotEmpty, IsString, Matches } from 'class-validator';
 
 export class CreateBuildingDto {
   @ApiProperty({
@@ -27,6 +27,9 @@ export class CreateBuildingDto {
   })
   @IsString()
   @IsNotEmpty()
+  @Matches(/^\((-?\d+(\.\d+)?),\s*(-?\d+(\.\d+)?)\)$/, {
+    message: 'GPS must be in format (latitude, longitude)',
+  })
   gps: string;
 
   @ApiProperty({

--- a/src/building/dto/req/createBuilding.dto.ts
+++ b/src/building/dto/req/createBuilding.dto.ts
@@ -1,0 +1,40 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateBuildingDto {
+  @ApiProperty({
+    type: String,
+    description: 'Building Name',
+    example: '대학 A동',
+  })
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @ApiProperty({
+    type: String,
+    description: 'Building Name in english',
+    example: 'College A',
+  })
+  @IsString()
+  @IsNotEmpty()
+  enName: string;
+
+  @ApiProperty({
+    type: String,
+    description: 'GPS info (lat, lon)',
+    example: '(35.229695, 126.844536)',
+  })
+  @IsString()
+  @IsNotEmpty()
+  gps: string;
+
+  @ApiProperty({
+    type: String,
+    description: 'Building Code',
+    example: 'N4',
+  })
+  @IsString()
+  @IsNotEmpty()
+  code: string;
+}

--- a/src/building/dto/req/updateBuilding.dto.ts
+++ b/src/building/dto/req/updateBuilding.dto.ts
@@ -1,0 +1,44 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+
+export class UpdateBuildingDto {
+  @ApiProperty({
+    type: String,
+    description: 'Building Name',
+    example: '대학 A동',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  name?: string;
+
+  @ApiProperty({
+    type: String,
+    description: 'Building Name in enlglish',
+    example: 'College A',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  enName?: string;
+
+  @ApiProperty({
+    type: String,
+    description: 'GPS info (lat, lon)',
+    example: '(35.229695, 126.844536)',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  gps: string;
+
+  @ApiProperty({
+    type: String,
+    description: 'Building Code',
+    example: 'N4',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  code: string;
+}

--- a/src/building/dto/req/updateBuilding.dto.ts
+++ b/src/building/dto/req/updateBuilding.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional, IsString } from 'class-validator';
+import { IsOptional, IsString, Matches } from 'class-validator';
 
 export class UpdateBuildingDto {
   @ApiProperty({
@@ -30,7 +30,10 @@ export class UpdateBuildingDto {
   })
   @IsString()
   @IsOptional()
-  gps: string;
+  @Matches(/^\((-?\d+(\.\d+)?),\s*(-?\d+(\.\d+)?)\)$/, {
+    message: 'GPS must be in format (latitude, longitude)',
+  })
+  gps?: string;
 
   @ApiProperty({
     type: String,
@@ -40,5 +43,5 @@ export class UpdateBuildingDto {
   })
   @IsString()
   @IsOptional()
-  code: string;
+  code?: string;
 }

--- a/src/building/dto/res/buildingRes.dto.ts
+++ b/src/building/dto/res/buildingRes.dto.ts
@@ -1,0 +1,11 @@
+export class BuildingResponseDto {
+  id: number;
+  name: string;
+  enName: string;
+
+  gps: string;
+  code: string;
+
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/post/dto/req/createPost.dto.ts
+++ b/src/post/dto/req/createPost.dto.ts
@@ -40,14 +40,14 @@ export class CreatePostDto {
   @IsOptional()
   images: string[] = [];
 
-  @ApiProperty({
-    type: String,
-    description: 'Location where the item was found or lost. To be configured',
-    example: '',
-  })
-  @IsString()
-  @IsNotEmpty()
-  location: string;
+  // @ApiProperty({
+  //   type: String,
+  //   description: 'Location where the item was found or lost. To be configured',
+  //   example: '',
+  // })
+  // @IsString()
+  // @IsNotEmpty()
+  // location: string;
 
   @ApiProperty({
     enum: ItemCategory,

--- a/src/post/dto/req/createPost.dto.ts
+++ b/src/post/dto/req/createPost.dto.ts
@@ -6,6 +6,7 @@ import {
   IsNotEmpty,
   IsOptional,
   IsString,
+  MaxLength,
 } from 'class-validator';
 
 export class CreatePostDto {
@@ -62,6 +63,7 @@ export class CreatePostDto {
   })
   @IsString()
   @IsNotEmpty()
+  @MaxLength(255)
   locationDetail: string;
 
   @ApiProperty({

--- a/src/post/dto/req/createPost.dto.ts
+++ b/src/post/dto/req/createPost.dto.ts
@@ -1,6 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { ItemCategory, PostType } from '@prisma/client';
-import { IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import {
+  IsEnum,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 
 export class CreatePostDto {
   @ApiProperty({
@@ -40,14 +46,23 @@ export class CreatePostDto {
   @IsOptional()
   images: string[] = [];
 
-  // @ApiProperty({
-  //   type: String,
-  //   description: 'Location where the item was found or lost. To be configured',
-  //   example: '',
-  // })
-  // @IsString()
-  // @IsNotEmpty()
-  // location: string;
+  @ApiProperty({
+    type: Number,
+    description: 'Building where the item was found or lost.',
+    example: 1,
+  })
+  @IsInt()
+  @IsNotEmpty()
+  buildingId: number;
+
+  @ApiProperty({
+    type: String,
+    description: 'Detailed location description.',
+    example: '206호로 추정',
+  })
+  @IsString()
+  @IsNotEmpty()
+  locationDetail: string;
 
   @ApiProperty({
     enum: ItemCategory,

--- a/src/post/dto/req/postFilter.dto.ts
+++ b/src/post/dto/req/postFilter.dto.ts
@@ -9,6 +9,7 @@ export class PostFilterDto {
     enumName: 'ItemCategory',
     description: 'Item category',
     example: ItemCategory.ELECTRONICS,
+    required: false,
   })
   @IsEnum(ItemCategory)
   @IsOptional()
@@ -19,6 +20,7 @@ export class PostFilterDto {
     enumName: 'PostType',
     description: 'Type of post (FOUND or LOST)',
     example: PostType.FOUND,
+    required: false,
   })
   @IsEnum(PostType)
   @IsOptional()
@@ -29,6 +31,7 @@ export class PostFilterDto {
     enumName: 'PostStatus',
     description: 'Post status',
     example: PostStatus.IN_PROGRESS,
+    required: false,
   })
   @IsEnum(PostStatus)
   @IsOptional()
@@ -36,8 +39,20 @@ export class PostFilterDto {
 
   @ApiProperty({
     type: Number,
+    description: 'Building Id',
+    example: 1,
+    required: false,
+  })
+  @Transform(({ value }) => parseInt(value), { toClassOnly: true })
+  @IsInt()
+  @IsOptional()
+  buildingId?: number;
+
+  @ApiProperty({
+    type: Number,
     description: 'Pagination cursor for next set of results',
     example: 0,
+    required: false,
   })
   @Transform(({ value }) => parseInt(value, 10), { toClassOnly: true })
   @IsInt()
@@ -46,12 +61,13 @@ export class PostFilterDto {
 
   @ApiProperty({
     type: Number,
-    description: 'Number of posts to return (maximum 20)',
-    example: 10,
+    description: 'Number of posts to return (maximum 100)',
+    example: 20,
+    required: false,
   })
   @Type(() => Number)
   @IsInt()
   @IsOptional()
-  @Max(20)
+  @Max(100)
   take?: number;
 }

--- a/src/post/dto/req/updatePost.dto.ts
+++ b/src/post/dto/req/updatePost.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { PostStatus } from '@prisma/client';
-import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { IsEnum, IsInt, IsOptional, IsString } from 'class-validator';
 
 export class UpdatePostDto {
   @ApiProperty({
@@ -33,4 +33,24 @@ export class UpdatePostDto {
   @IsEnum(PostStatus)
   @IsOptional()
   status?: PostStatus;
+
+  @ApiProperty({
+    type: Number,
+    description: 'Building where the item was found or lost.',
+    example: 1,
+    required: false,
+  })
+  @IsInt()
+  @IsOptional()
+  buildingId?: number;
+
+  @ApiProperty({
+    type: String,
+    description: 'Detailed location description.',
+    example: '204호로 추정',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  locationDetail?: string;
 }

--- a/src/post/dto/req/updatePost.dto.ts
+++ b/src/post/dto/req/updatePost.dto.ts
@@ -1,6 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { PostStatus } from '@prisma/client';
-import { IsEnum, IsInt, IsOptional, IsString } from 'class-validator';
+import {
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  MaxLength,
+} from 'class-validator';
 
 export class UpdatePostDto {
   @ApiProperty({
@@ -52,5 +58,6 @@ export class UpdatePostDto {
   })
   @IsString()
   @IsOptional()
+  @MaxLength(255)
   locationDetail?: string;
 }

--- a/src/post/dto/res/postRes.dto.ts
+++ b/src/post/dto/res/postRes.dto.ts
@@ -16,7 +16,7 @@ export class PostResponseDto {
 
   images: string[];
 
-  location: string;
+  // location: string;
 
   category: ItemCategory;
 

--- a/src/post/dto/res/postRes.dto.ts
+++ b/src/post/dto/res/postRes.dto.ts
@@ -5,6 +5,14 @@ export class AuthorDto {
   name: string;
 }
 
+export class BuildingDto {
+  id: number;
+  name: string;
+  enName: string;
+  gps: string;
+  code: string;
+}
+
 export class PostResponseDto {
   id: number;
 
@@ -16,13 +24,15 @@ export class PostResponseDto {
 
   images: string[];
 
-  // location: string;
-
   category: ItemCategory;
 
   status: PostStatus;
 
   author: AuthorDto;
+
+  building: BuildingDto;
+
+  locationDetail: string;
 
   createdAt: Date;
 

--- a/src/post/post.controller.ts
+++ b/src/post/post.controller.ts
@@ -36,7 +36,7 @@ export class PostController {
 
   @ApiOperation({
     summary: 'get post list',
-    description: 'get post list with filter query',
+    description: 'You can get post list with filter query.',
   })
   @ApiOkResponse({
     type: PostListDto,

--- a/src/post/post.module.ts
+++ b/src/post/post.module.ts
@@ -7,6 +7,7 @@ import { PostService } from './post.service';
 import { PostRepository } from './post.repository';
 import { PrismaModule } from 'src/prisma/prisma.module';
 import { ImageModule } from 'src/image/image.module';
+import { BuildingModule } from 'src/building/building.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { ImageModule } from 'src/image/image.module';
     UserModule,
     PrismaModule,
     ImageModule,
+    BuildingModule,
   ],
   providers: [PostService, PostRepository],
   controllers: [PostController],

--- a/src/post/post.repository.ts
+++ b/src/post/post.repository.ts
@@ -12,12 +12,20 @@ export class PostRepository {
   constructor(private prismaService: PrismaService) {}
 
   async findPostList(postFilterDto: PostFilterDto): Promise<PostResponseDto[]> {
-    const { category, type, status, cursor, take = 10 } = postFilterDto;
+    const {
+      category,
+      type,
+      status,
+      buildingId,
+      cursor,
+      take = 10,
+    } = postFilterDto;
 
     const where = {
       ...(category && { category }),
       ...(type && { type }),
       ...(status && { status }),
+      ...(buildingId && { buildingId }),
     };
 
     const postList = await this.prismaService.post.findMany({
@@ -32,6 +40,15 @@ export class PostRepository {
             name: true,
           },
         },
+        building: {
+          select: {
+            id: true,
+            name: true,
+            enName: true,
+            gps: true,
+            code: true,
+          },
+        },
       },
     });
 
@@ -41,7 +58,10 @@ export class PostRepository {
       title: post.title,
       description: post.description,
       images: post.images,
-      // location: post.location as string,
+
+      building: post.building,
+      locationDetail: post.locationDetail,
+
       category: post.category,
       status: post.status,
       author: post.author,
@@ -57,7 +77,15 @@ export class PostRepository {
     // const { type, title, description, images, location, category } =
     //   createPostDto;
 
-    const { type, title, description, images, category } = createPostDto;
+    const {
+      type,
+      title,
+      description,
+      images,
+      category,
+      buildingId,
+      locationDetail,
+    } = createPostDto;
 
     const post = await this.prismaService.post.create({
       data: {
@@ -66,11 +94,16 @@ export class PostRepository {
             uuid: userUuid,
           },
         },
+        building: {
+          connect: {
+            id: buildingId,
+          },
+        },
         type,
         title,
         description,
         images,
-        // location,
+        locationDetail,
         category,
         status: 'IN_PROGRESS',
       },
@@ -79,6 +112,15 @@ export class PostRepository {
           select: {
             uuid: true,
             name: true,
+          },
+        },
+        building: {
+          select: {
+            id: true,
+            name: true,
+            enName: true,
+            gps: true,
+            code: true,
           },
         },
       },
@@ -90,7 +132,10 @@ export class PostRepository {
       title: post.title,
       description: post.description,
       images: post.images,
-      // location: post.location as string,
+
+      building: post.building,
+      locationDetail: post.locationDetail,
+
       category: post.category,
       status: post.status,
       author: post.author,
@@ -112,6 +157,15 @@ export class PostRepository {
             name: true,
           },
         },
+        building: {
+          select: {
+            id: true,
+            name: true,
+            enName: true,
+            gps: true,
+            code: true,
+          },
+        },
       },
     });
 
@@ -121,7 +175,10 @@ export class PostRepository {
       title: post.title,
       description: post.description,
       images: post.images,
-      // location: post.location as string,
+
+      building: post.building,
+      locationDetail: post.locationDetail,
+
       category: post.category,
       status: post.status,
       author: post.author,
@@ -140,6 +197,15 @@ export class PostRepository {
             name: true,
           },
         },
+        building: {
+          select: {
+            id: true,
+            name: true,
+            enName: true,
+            gps: true,
+            code: true,
+          },
+        },
       },
     });
 
@@ -151,7 +217,10 @@ export class PostRepository {
       title: post.title,
       description: post.description,
       images: post.images,
-      // location: post.location as string, // 변환 추가
+
+      building: post.building,
+      locationDetail: post.locationDetail,
+
       category: post.category,
       status: post.status,
       author: post.author,
@@ -174,6 +243,15 @@ export class PostRepository {
             name: true,
           },
         },
+        building: {
+          select: {
+            id: true,
+            name: true,
+            enName: true,
+            gps: true,
+            code: true,
+          },
+        },
       },
     });
 
@@ -183,7 +261,10 @@ export class PostRepository {
       title: updatedPost.title,
       description: updatedPost.description,
       images: updatedPost.images,
-      // location: updatedPost.location as string,
+
+      building: updatedPost.building,
+      locationDetail: updatedPost.locationDetail,
+
       category: updatedPost.category,
       status: updatedPost.status,
       author: updatedPost.author,

--- a/src/post/post.repository.ts
+++ b/src/post/post.repository.ts
@@ -41,7 +41,7 @@ export class PostRepository {
       title: post.title,
       description: post.description,
       images: post.images,
-      location: post.location as string,
+      // location: post.location as string,
       category: post.category,
       status: post.status,
       author: post.author,
@@ -54,8 +54,10 @@ export class PostRepository {
     createPostDto: CreatePostDto,
     userUuid: string,
   ): Promise<PostResponseDto> {
-    const { type, title, description, images, location, category } =
-      createPostDto;
+    // const { type, title, description, images, location, category } =
+    //   createPostDto;
+
+    const { type, title, description, images, category } = createPostDto;
 
     const post = await this.prismaService.post.create({
       data: {
@@ -68,7 +70,7 @@ export class PostRepository {
         title,
         description,
         images,
-        location,
+        // location,
         category,
         status: 'IN_PROGRESS',
       },
@@ -88,7 +90,7 @@ export class PostRepository {
       title: post.title,
       description: post.description,
       images: post.images,
-      location: post.location as string,
+      // location: post.location as string,
       category: post.category,
       status: post.status,
       author: post.author,
@@ -119,7 +121,7 @@ export class PostRepository {
       title: post.title,
       description: post.description,
       images: post.images,
-      location: post.location as string,
+      // location: post.location as string,
       category: post.category,
       status: post.status,
       author: post.author,
@@ -149,7 +151,7 @@ export class PostRepository {
       title: post.title,
       description: post.description,
       images: post.images,
-      location: post.location as string, // 변환 추가
+      // location: post.location as string, // 변환 추가
       category: post.category,
       status: post.status,
       author: post.author,
@@ -181,7 +183,7 @@ export class PostRepository {
       title: updatedPost.title,
       description: updatedPost.description,
       images: updatedPost.images,
-      location: updatedPost.location as string,
+      // location: updatedPost.location as string,
       category: updatedPost.category,
       status: updatedPost.status,
       author: updatedPost.author,

--- a/src/post/post.service.ts
+++ b/src/post/post.service.ts
@@ -12,6 +12,7 @@ import { UpdatePostDto } from './dto/req/updatePost.dto';
 import { PostFilterDto } from './dto/req/postFilter.dto';
 import { ImageService } from 'src/image/image.service';
 import { MyPostFilterDto } from './dto/req/myPostFilter.dto';
+import { BuildingService } from 'src/building/building.service';
 
 @Injectable()
 export class PostService {
@@ -21,6 +22,7 @@ export class PostService {
     private configService: ConfigService,
     private postRepository: PostRepository,
     private imageService: ImageService,
+    private buildingSergice: BuildingService,
   ) {
     // S3 URL 기본 경로 설정
     this.s3Url = `https://${this.configService.get<string>(
@@ -97,6 +99,14 @@ export class PostService {
     createPostDto: CreatePostDto,
     userUuid: string,
   ): Promise<PostResponseDto> {
+    const building = this.buildingSergice.getBuildingById(
+      createPostDto.buildingId,
+    );
+
+    if (!building) {
+      throw new NotFoundException('Building not found.');
+    }
+
     if (createPostDto.images.length) {
       await this.imageService.validateImages(createPostDto.images);
     }


### PR DESCRIPTION
### What Changed
- Added the `Building` module(CRUD) to support building relationships in posts.
- Updated the `Post` schema to include `buildingId` and `locationDetail`.
- Modified `PostService`, `PostController` and 'PostRepository` to handle building relationships.
- Implemented validation for `buildingId` in `createPost`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `Building` model and associated functionalities for managing buildings.
	- Added `buildingId` and `locationDetail` fields to the `Post` model.
	- Implemented RESTful API endpoints for creating, retrieving, updating, and deleting buildings.
	- Enhanced post retrieval to include building details.

- **Bug Fixes**
	- Added validation to ensure a valid building is associated with posts during creation.

- **Documentation**
	- Enhanced API documentation with updated descriptions and metadata for new fields.

- **Refactor**
	- Updated existing data transfer objects (DTOs) to include new properties and improve structure.

- **Chores**
	- Added necessary imports and module dependencies for the new `Building` functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->